### PR TITLE
Docker container with startrek-db pre-loaded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM postgres:13-alpine
+
+COPY docker-load-db.sh /docker-entrypoint-initdb.d/
+COPY schema.sql /dumps/
+COPY data.sql /dumps/

--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ on 9.4).
 
 Once you have PostgreSQL installed and running, I recommend creating a
 new database, probably with a name like `startrek`, to load the schema
-and data into.  A separate database isnʼt strictly required, but you
+and data into. A separate database isnʼt strictly required, but you
 may run into collision issues by using another.
 
 As the database superuser, run `CREATE EXTENSION pgcrypto` on the
@@ -42,7 +42,18 @@ commands should load the schema and the data:
 
   $ psql -f schema.sql startrek
   $ psql -f data.sql startrek
+  
+=== Using it on a Docker container
+You can also use it on a Docker image with the database pre-loaded.
 
+To build the image issue:
+
+  $ docker build -t postgres-startrek .
+  
+This creates a Docker image tagged  `postgres-startrek` based on https://hub.docker.com/_/postgres[PostgreSQL official image] (https://github.com/docker-library/postgres/blob/b9c080857b880202ebd23c59d33fe86d7a70fea3/13/alpine/Dockerfile[13-alpine tag]).
+
+To see how to use this image check the https://hub.docker.com/_/postgres[PostreSQL image documentation].
+  
 == Moving forward
 
 Iʼll be happy to accept additions and improvements to the database.

--- a/docker-load-db.sh
+++ b/docker-load-db.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+psql -U postgres -c 'CREATE DATABASE startrek'
+psql -U postgres -d startrek -c 'CREATE EXTENSION pgcrypto'
+psql -U postgres -f /dumps/schema.sql startrek
+psql -U postgres -f /dumps/data.sql startrek


### PR DESCRIPTION
Added support for building an Docker image based on the official PostgreSQL image (13-apline tag) that will load the startrek-db on first boot.